### PR TITLE
Trying mongos Decimal128

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: clojure
 lein: lein
 before_script:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+  - echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
   - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=3.6.4
+  - sudo apt-get install -y mongodb-org
   - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
   - mongo --version
 script: lein midje

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: clojure
 lein: lein
+before_script:
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-get update
+  - sudo apt-get install -y mongodb-org=3.6.4
+  - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
+  - mongo --version
 script: lein midje
 jdk:
   - openjdk7

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [com.taoensso/timbre "4.10.0"]
 
                  ;; mongodb
-                 [com.novemberain/monger "3.1.0"]]
+                 [org.clojars.dyne/monger "3.2.0-SNAPSHOT"]]
 
   :source-paths ["src" "test"]
   :resource-paths ["resources" "test-resources"]


### PR DESCRIPTION
This update is needed in order to use the unreleased version of Monger supporting Decimal128 https://api.mongodb.com/python/3.4.0/api/bson/decimal128.html
@jaromil this is part of the numerical precision fix