### PR TITLE
 Adding per page listing in order to use pagination and avoid JVM cra…

### DIFF
--- a/src/clj_storage/core.clj
+++ b/src/clj_storage/core.clj
@@ -34,6 +34,8 @@
     "Retrieve item based on primary id")
   (query [e query]
     "Items are returned using a query map")
+  (list-per-page [e query page per-page]
+    "List all items in a collection using pagination. Per page is the number of items per page and page is the number of page. Items are sorted by _id")
   (delete! [e k]
     "Delete item based on primary id")
   (delete-all! [e]

--- a/src/clj_storage/core.clj
+++ b/src/clj_storage/core.clj
@@ -43,7 +43,9 @@
   (aggregate [e formula]
     "Process data records and return computed results")
   (count-since [e date-time formula]
-    "Count the number of records that since a date-time and after applying a formula. {} for an empty formula. This is meant only for collections that contain a `created-at` field.")) 
+    "Count the number of documents that since a date-time and after applying a formula. {} for an empty formula. This is meant only for collections that contain a `created-at` field.")
+  (count* [e params]
+    "Count the number of documents after applying a formula. {} for an empty formula.")) 
 
 (defrecord MemoryStore [data]
   Store

--- a/src/clj_storage/db/mongo.clj
+++ b/src/clj_storage/db/mongo.clj
@@ -89,8 +89,12 @@
 
   (count-since [this from-date-time formula]
     (let [dt-condition {:created-at {$gt from-date-time}}]
-      (mc/count (:mongo-db this) coll (merge formula
-                                             dt-condition)))))
+      (mc/count mongo-db coll (merge formula
+                                     dt-condition))))
+
+  (count* [this formula]
+    (mc/count mongo-db coll formula)))
+
 (defn create-mongo-store
   ([mongo-db coll]
    (create-mongo-store mongo-db coll {}))

--- a/src/clj_storage/db/mongo.clj
+++ b/src/clj_storage/db/mongo.clj
@@ -26,7 +26,8 @@
             [monger
              [db :as mdb]
              [core :as mongo]
-             [collection :as mcol]]
+             [collection :as mcol]
+             [query :as mq]]
             [monger.operators :refer [$gt]]
             [clj-storage.core :as storage :refer [Store]]
             [taoensso.timbre :as log]))
@@ -67,6 +68,15 @@
     (->> (mc/find-maps mongo-db coll query)
          (map #(dissoc % :_id))))
 
+  (list-per-page [this query page per-page]
+    (vec (map
+          ;; TODO: can this be done by the monger query lib?
+          #(dissoc % :_id)
+          (mq/with-collection mongo-db coll
+            (mq/find query)
+            (mq/sort {:timestamp -1})
+            (mq/paginate :page page :per-page per-page)))))
+  
   (delete! [this k]
     (when k
       (mc/remove-by-id mongo-db coll k)))

--- a/test/clj_storage/test/db/mongo.clj
+++ b/test/clj_storage/test/db/mongo.clj
@@ -53,7 +53,7 @@
                              (count (mcol/indexes-on (test-db/get-test-db) "simple-store")) => 1
                              (count (mcol/indexes-on (test-db/get-test-db) "store-with-ttl")) => 2
 
-                             (fact "Test mongo updates" 
+                             (fact "Test mongo updates." 
                                     (storage/store! (:transaction-store stores) :_id {:_id (rand-int 20000)
                                                                                       :currency :mongo
                                                                                       :from-id "an-account"
@@ -65,4 +65,15 @@
                                     (let [item (mcol/find-one-as-map (test-db/get-test-db) "transaction-store" {:transaction-id "1"})
                                           updated-item ((fn [doc] (update doc :amount #(+ % 1))) item)]
                                       (:amount updated-item) => 1001)
-                                    (:amount (storage/update! (:transaction-store stores) {:transaction-id "1"} (fn [doc] (update doc :amount #(+ % 1))))) => 1001))))
+                                    (:amount (storage/update! (:transaction-store stores) {:transaction-id "1"} (fn [doc] (update doc :amount #(+ % 1))))) => 1001)
+
+                             (fact "Test total count."
+                                   (storage/count* (:transaction-store stores) {}) => 1
+                                   (storage/store! (:transaction-store stores) :_id {:_id (rand-int 20000)
+                                                                                      :currency :mongo
+                                                                                      :from-id "yet-an-account"
+                                                                                      :to-id "another-account"
+                                                                                      :tags []
+                                                                                      :amount 1000
+                                                                                     :transaction-id "2"})
+                                   (storage/count* (:transaction-store stores) {}) => 2))))


### PR DESCRIPTION
…shes

Get rid of :_id from results (monger query adds it by default)

@jaromil this is meant to replace any "list" requests with paging. Monger provides a great paging feature plus the mongo query lib is very flexible so nice to use for all lookups imo